### PR TITLE
Dont use record when not created.

### DIFF
--- a/app/Filament/Resources/Pages/Schemas/PageForm.php
+++ b/app/Filament/Resources/Pages/Schemas/PageForm.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\Pages\Schemas;
 
 use App\Models\Page;
+use Filament\Support\Enums\Operation;
 use Livewire\Component;
 use Filament\Actions\Action;
 use App\Support\SlugGenerator;
@@ -50,8 +51,12 @@ class PageForm
 
                         TextInput::make('slug')
                             ->partiallyRenderAfterStateUpdated()
-                            ->helperText(function ($record) {
-                                $url = route('pages.show', $record);
+                            ->helperText(function ($record, $operation) {
+                                if ($operation === Operation::Create->value) {
+                                    return new HtmlString('The slug is auto-generated from the title. You can change it if you want.');
+                                }
+
+                                $url = route('pages.show', ['page' => $record]);
                                 return new HtmlString(Blade::render("<a href=\"{$url}\" target=\"_blank\"><x-heroicon-m-arrow-top-right-on-square class='size-3 mr-1 inline'/>{$url}</a>"));
                             }),
 


### PR DESCRIPTION
I visited the "Create page" page and an error was showing.
It's trying to create a link to the SLug's URL, which cant be done while not created.
Also, then I noticed the "Publish" panel is also available while creation, which also can't happen