### PR TITLE
Add playground restructuring workflow

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -1,0 +1,67 @@
+name: Playground Branch
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  restructure:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Restructure repository
+        run: |
+          mkdir -p packages/plume
+
+          # Move everything into packages/plume, except .git and playground
+          for item in $(ls -A); do
+            case "$item" in
+              .git|playground|packages) ;;
+              *) mv "$item" packages/plume/ ;;
+            esac
+          done
+
+          # Move playground contents to root (including dotfiles)
+          mv playground/* playground/.[!.]* . 2>/dev/null || true
+          rm -rf playground
+
+      - name: Update composer.json repository path
+        run: |
+          jq '.repositories["meetplume/plume"].url = "./packages/plume" |
+              del(.repositories["meetplume/plume"].options)' \
+            composer.json > composer.json.tmp && mv composer.json.tmp composer.json
+
+      - name: Extend .gitignore for package subfolder
+        run: |
+          echo "" >> .gitignore
+          echo "# Package development" >> .gitignore
+          echo "/packages/plume/vendor" >> .gitignore
+          echo "/packages/plume/node_modules" >> .gitignore
+          echo "/packages/plume/.phpunit.cache" >> .gitignore
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: dom, mbstring, zip
+
+      - name: Update composer.lock for new package path
+        run: composer update meetplume/plume --no-interaction --no-scripts
+
+      - name: Commit and push to playground branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B playground
+          git add -A
+          git commit -m "Restructure: playground as root, package in packages/plume"
+          git push --force origin playground


### PR DESCRIPTION
## Summary
Adds a GitHub Action that automatically generates a `playground` branch with the repository restructured so the Laravel app is at root and the Plume package is nested under `packages/plume/`.

- Moves all root files into `packages/plume/` (except `.git` and `playground/)
- Moves all playground contents to repository root
- Updates `composer.json` to reference the package at the new path
- Force-pushes to `playground` branch on every push to `main`

## Test plan
- [ ] Push to `main` or trigger `workflow_dispatch` to run the workflow
- [ ] Verify the `playground` branch has the correct structure:
  - Root contains Laravel app files (`artisan`, `app/`, `routes/`, etc.)
  - `packages/plume/` contains the package (`src/`, `composer.json`, etc.)
  - `composer.lock` is valid with updated path reference
- [ ] Verify `composer install` works on the `playground` branch

🤖 Generated with Claude Code