### PR TITLE
customizer

### DIFF
--- a/playground/content/config.yml
+++ b/playground/content/config.yml
@@ -5,7 +5,7 @@ theme: default
 primary: '#338737'
 
 # available values for gray: slate, gray, zinc, neutral, stone, mauve, olive, mist, taupe
-gray: neutral
+gray: gray
 
 # available values for radius: none, small, medium, large
 radius: large

--- a/playground/content/config.yml
+++ b/playground/content/config.yml
@@ -1,4 +1,4 @@
-# available values for theme: default, brutalist, catppuccin, forest, ocean, rose
+# available values for theme: brutalist, catppuccin, default, forest, ocean, rose
 theme: default
 
 # available values for primary: any tailwindcss color like (blue, red, green, yellow, ...) or arbitrary value

--- a/playground/tests/Feature/CustomizerControllerTest.php
+++ b/playground/tests/Feature/CustomizerControllerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use Meetplume\Plume\Facades\Plume;
+use Meetplume\Plume\ThemeConfig;
+
+beforeEach(function (): void {
+    $this->configPath = sys_get_temp_dir().'/plume_test_'.uniqid().'.yml';
+    ThemeConfig::write($this->configPath, ['theme' => 'default', 'primary' => 'neutral', 'gray' => 'neutral', 'radius' => 'medium', 'spacing' => 'default', 'dark' => false]);
+    Plume::config($this->configPath);
+});
+
+afterEach(function (): void {
+    if (file_exists($this->configPath)) {
+        unlink($this->configPath);
+    }
+});
+
+it('updates config file and returns resolved values', function (): void {
+    $response = $this->postJson('/_plume/customizer', [
+        'primary' => 'blue',
+        'radius' => 'large',
+    ]);
+
+    $response->assertSuccessful();
+    $response->assertJsonFragment(['primary' => 'blue', 'radius' => 'large']);
+
+    $config = new ThemeConfig($this->configPath);
+    expect($config->toArray()['primary'])->toBe('blue');
+    expect($config->toArray()['radius'])->toBe('large');
+});
+
+it('returns 422 for invalid radius', function (): void {
+    $response = $this->postJson('/_plume/customizer', [
+        'radius' => 'invalid',
+    ]);
+
+    $response->assertUnprocessable();
+});
+
+it('switches preset when theme sent alone', function (): void {
+    $response = $this->postJson('/_plume/customizer', [
+        'theme' => 'ocean',
+    ]);
+
+    $response->assertSuccessful();
+
+    $content = file_get_contents($this->configPath);
+    expect($content)->toContain('theme: ocean');
+    expect($content)->not->toContain('primary:');
+});
+
+it('resets to defaults', function (): void {
+    $this->postJson('/_plume/customizer', ['primary' => 'red']);
+
+    $response = $this->postJson('/_plume/customizer/reset');
+
+    $response->assertSuccessful();
+    $response->assertJsonFragment(['primary' => 'neutral', 'radius' => 'medium']);
+});
+
+it('preserves theme key on reset', function (): void {
+    $response = $this->postJson('/_plume/customizer/reset');
+
+    $response->assertSuccessful();
+
+    $content = file_get_contents($this->configPath);
+    expect($content)->toContain('theme: default');
+});

--- a/resources/css/customizer.css
+++ b/resources/css/customizer.css
@@ -110,7 +110,8 @@
 
 /* Pill buttons (radius, spacing) */
 .cz-pills {
-    display: flex;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
     flex-wrap: wrap;
     gap: 6px;
 }
@@ -118,8 +119,8 @@
 .cz-pill {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
-    padding: 3px 8px;
+    gap: 6px;
+    padding: 6px 12px;
     font-size: 12px;
     font-weight: 500;
     border-radius: 6px;
@@ -305,26 +306,26 @@
     height: 12px;
     border-top: 2px solid currentColor;
     border-left: 2px solid currentColor;
-    opacity: 0.5;
+    opacity: 0.4;
 }
 
 /* Spacing preview icon inside pill — 3 lines with varying gap */
 .cz-spacing-icon {
     display: flex;
     flex-direction: column;
-    width: 10px;
-    opacity: 0.5;
+    width: 12px;
+    opacity: 0.4;
 }
 
 .cz-spacing-icon span {
     width: 100%;
-    height: 1.5px;
+    height: 2px;
     background: currentColor;
     border-radius: 1px;
 }
 
 .cz-spacing-icon[data-spacing='dense'] {
-    height: 6px;
+    height: 7px;
     justify-content: space-between;
 }
 
@@ -334,12 +335,12 @@
 }
 
 .cz-spacing-icon[data-spacing='default'] {
-    height: 10px;
+    height: 9px;
     justify-content: space-between;
 }
 
 .cz-spacing-icon[data-spacing='spacious'] {
-    height: 12px;
+    height: 10px;
     justify-content: space-between;
 }
 

--- a/resources/css/customizer.css
+++ b/resources/css/customizer.css
@@ -271,13 +271,46 @@
     transform: translateX(16px);
 }
 
+/* Action buttons row */
+.cz-actions {
+    display: flex;
+    gap: 6px;
+}
+
+/* Save button */
+.cz-save {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    flex: 1;
+    height: 32px;
+    border-radius: 6px;
+    border: 1px solid var(--cz-active-bg);
+    background: var(--cz-active-bg);
+    color: var(--cz-active-fg);
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: opacity 0.15s;
+}
+
+.cz-save:hover {
+    opacity: 0.85;
+}
+
+.cz-save:disabled {
+    opacity: 0.6;
+    cursor: default;
+}
+
 /* Reset button */
 .cz-reset {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     gap: 6px;
-    width: 100%;
+    flex: 1;
     height: 32px;
     border-radius: 6px;
     border: 1px solid var(--cz-border);

--- a/resources/css/customizer.css
+++ b/resources/css/customizer.css
@@ -1,0 +1,410 @@
+.plume-customizer {
+    --cz-bg: #fff;
+    --cz-fg: #111;
+    --cz-border: #e5e5e5;
+    --cz-muted: #737373;
+    --cz-active-bg: #111;
+    --cz-active-fg: #fff;
+    --cz-hover-bg: #f5f5f5;
+    --cz-toggle-off: #d4d4d4;
+    --cz-shadow: 0 4px 24px rgba(0, 0, 0, 0.12);
+}
+
+.dark .plume-customizer {
+    --cz-bg: #1c1c1c;
+    --cz-fg: #e5e5e5;
+    --cz-border: #333;
+    --cz-muted: #888;
+    --cz-active-bg: #e5e5e5;
+    --cz-active-fg: #111;
+    --cz-hover-bg: #2a2a2a;
+    --cz-toggle-off: #555;
+    --cz-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+}
+
+/* Container */
+.plume-customizer {
+    position: fixed;
+    bottom: 20px;
+    left: 20px;
+    z-index: 50;
+    font-family: system-ui, sans-serif;
+}
+
+/* Panel */
+.cz-panel {
+    margin-bottom: 8px;
+    width: 340px;
+    border-radius: 14px;
+    border: 1px solid var(--cz-border);
+    background: oklch(1 0 0 / 0.9);
+    backdrop-filter: blur(8px);
+    color: var(--cz-fg);
+    padding: 16px;
+    box-shadow: var(--cz-shadow);
+    max-height: calc(100vh - 88px);
+    overflow-y: auto;
+}
+@media (max-width: 380px) {
+    .cz-panel {
+        width: calc(100% - 20px);
+    }
+}
+
+.cz-title {
+    margin-bottom: 16px;
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--cz-fg);
+}
+
+.cz-sections {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+/* Labels */
+.cz-label {
+    font-size: 12px;
+    font-weight: 500;
+    margin-bottom: 6px;
+    color: var(--cz-fg);
+}
+
+/* Swatch grid (colors) */
+.cz-swatches {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    padding-top: 4px;
+    overflow: visible;
+}
+
+.cz-swatch {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 1px solid var(--cz-border);
+    cursor: pointer;
+    padding: 0;
+    transition: transform 0.1s;
+}
+
+.cz-swatch:hover {
+    transform: scale(1.1);
+}
+
+.cz-swatch[data-active='true'] {
+    border-color: var(--cz-fg);
+    outline: 1px solid var(--cz-fg);
+}
+
+/* Pill buttons (radius, spacing) */
+.cz-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.cz-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 8px;
+    font-size: 12px;
+    font-weight: 500;
+    border-radius: 6px;
+    border: 1px solid var(--cz-border);
+    background: oklch(1 0 0 / 0.3);
+    color: var(--cz-fg);
+    cursor: pointer;
+    white-space: nowrap;
+    transition:
+        background 0.15s,
+        border-color 0.15s;
+}
+
+.cz-pill:hover {
+    background: var(--cz-hover-bg);
+}
+
+.cz-pill[data-active='true'] {
+    border-color: var(--cz-active-bg);
+    background: var(--cz-active-bg);
+    color: var(--cz-active-fg);
+}
+
+/* Preset grid */
+.cz-preset-list {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+}
+
+.cz-preset-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 6px;
+    border: 1px solid var(--cz-border);
+    border-radius: 8px;
+    background: oklch(1 0 0 / 0.3);
+    color: var(--cz-fg);
+    font-size: 12px;
+    font-weight: 400;
+    cursor: pointer;
+    transition:
+        background 0.15s,
+        border-color 0.15s;
+    text-align: left;
+}
+
+.cz-preset-item:hover {
+    background: var(--cz-hover-bg);
+}
+
+.cz-preset-item[data-active='true'] {
+    border-color: var(--cz-active-bg);
+    background: var(--cz-hover-bg);
+    font-weight: 600;
+}
+
+.cz-preset-dots {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 3px;
+    width: 24px;
+    height: 24px;
+    padding: 4px;
+    border-radius: 5px;
+    background: #ffffff;
+    flex-shrink: 0;
+    box-shadow: 0 0 2px rgba(0, 0, 0, 0.25);
+}
+
+.cz-preset-dots[data-dark='true'] {
+    background: #222;
+}
+
+.cz-preset-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.cz-preset-name {
+    flex: 1;
+    min-width: 0;
+}
+
+/* Toggle row */
+.cz-toggle-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.cz-toggle {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    width: 36px;
+    height: 20px;
+    border-radius: 10px;
+    border: none;
+    cursor: pointer;
+    padding: 2px;
+    transition: background 0.2s;
+    background: var(--cz-toggle-off);
+}
+
+.cz-toggle[data-on='true'] {
+    background: var(--cz-active-bg);
+}
+
+.cz-toggle-knob {
+    display: block;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--cz-bg);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    transition: transform 0.2s;
+    transform: translateX(0);
+}
+
+.cz-toggle[data-on='true'] .cz-toggle-knob {
+    transform: translateX(16px);
+}
+
+/* Reset button */
+.cz-reset {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    width: 100%;
+    height: 32px;
+    border-radius: 6px;
+    border: 1px solid var(--cz-border);
+    background: transparent;
+    color: var(--cz-fg);
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.cz-reset:hover {
+    background: var(--cz-hover-bg);
+}
+
+/* Floating toggle button */
+.cz-fab {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    border: none;
+    background: var(--cz-active-bg);
+    color: var(--cz-active-fg);
+    cursor: pointer;
+    box-shadow: var(--cz-shadow);
+    transition: background 0.15s;
+}
+
+.cz-fab:hover {
+    opacity: 0.85;
+}
+
+/* Radius preview icon inside pill */
+.cz-radius-icon {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-top: 2px solid currentColor;
+    border-left: 2px solid currentColor;
+    opacity: 0.5;
+}
+
+/* Spacing preview icon inside pill — 3 lines with varying gap */
+.cz-spacing-icon {
+    display: flex;
+    flex-direction: column;
+    width: 10px;
+    opacity: 0.5;
+}
+
+.cz-spacing-icon span {
+    width: 100%;
+    height: 1.5px;
+    background: currentColor;
+    border-radius: 1px;
+}
+
+.cz-spacing-icon[data-spacing='dense'] {
+    height: 6px;
+    justify-content: space-between;
+}
+
+.cz-spacing-icon[data-spacing='compact'] {
+    height: 8px;
+    justify-content: space-between;
+}
+
+.cz-spacing-icon[data-spacing='default'] {
+    height: 10px;
+    justify-content: space-between;
+}
+
+.cz-spacing-icon[data-spacing='spacious'] {
+    height: 12px;
+    justify-content: space-between;
+}
+
+/* Custom color picker swatch */
+.cz-custom-color {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: 1px dashed var(--cz-muted);
+    cursor: pointer;
+    padding: 0;
+    transition: transform 0.1s;
+}
+
+.cz-custom-color:hover {
+    transform: scale(1.1);
+}
+
+.cz-custom-color[data-active='true'] {
+    border-color: var(--cz-fg);
+    border-style: solid;
+    outline: 1px solid var(--cz-fg);
+}
+
+.cz-color-input {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+    background: none;
+    overflow: hidden;
+}
+
+.cz-color-input::-webkit-color-swatch-wrapper {
+    padding: 0;
+}
+
+.cz-color-input::-webkit-color-swatch {
+    border: none;
+    border-radius: 50%;
+}
+
+.cz-color-input::-moz-color-swatch {
+    border: none;
+    border-radius: 50%;
+}
+
+.cz-custom-color .cz-check {
+    position: relative;
+    z-index: 2;
+    pointer-events: none;
+}
+
+/* Check icon in swatches */
+.cz-check {
+    width: 14px;
+    height: 14px;
+    color: #fff;
+}
+
+/* Pin theme vars on customizer tooltips (portaled to body) */
+.plume-customizer-tooltip {
+    --primary: #111;
+    --primary-foreground: #fff;
+    --radius: 0.5rem;
+    --spacing: 0.25rem;
+}
+
+.dark .plume-customizer-tooltip {
+    --primary: #e5e5e5;
+    --primary-foreground: #111;
+}

--- a/resources/css/customizer.css
+++ b/resources/css/customizer.css
@@ -120,10 +120,10 @@
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    padding: 6px 12px;
+    padding: 7px 12px;
     font-size: 12px;
     font-weight: 500;
-    border-radius: 6px;
+    border-radius: 8px;
     border: 1px solid var(--cz-border);
     background: oklch(1 0 0 / 0.3);
     color: var(--cz-fg);
@@ -144,8 +144,7 @@
 
 .cz-pill[data-active='true'] {
     border-color: var(--cz-active-bg);
-    background: var(--cz-active-bg);
-    color: var(--cz-active-fg);
+    background: var(--cz-hover-bg);
 }
 
 /* Preset grid */
@@ -191,9 +190,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    gap: 3px;
-    width: 24px;
-    height: 24px;
+    gap: 2px;
+    width: 20px;
+    height: 20px;
     padding: 4px;
     border-radius: 5px;
     background: #ffffff;

--- a/resources/css/customizer.css
+++ b/resources/css/customizer.css
@@ -51,6 +51,10 @@
     }
 }
 
+.dark .cz-panel {
+    background: oklch(0.222 0 90 / 0.9);
+}
+
 .cz-title {
     margin-bottom: 16px;
     font-weight: 600;
@@ -129,6 +133,10 @@
         border-color 0.15s;
 }
 
+.dark .cz-pill {
+    background: oklch(0.222 0 90 / 0.3);
+}
+
 .cz-pill:hover {
     background: var(--cz-hover-bg);
 }
@@ -162,6 +170,10 @@
         background 0.15s,
         border-color 0.15s;
     text-align: left;
+}
+
+.dark .cz-preset-item {
+    background: oklch(0.222 0 90 / 0.3);
 }
 
 .cz-preset-item:hover {

--- a/resources/css/customizer.css
+++ b/resources/css/customizer.css
@@ -162,6 +162,63 @@
     background: var(--cz-hover-bg);
 }
 
+/* Preset dropdown */
+.cz-preset-dropdown {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.cz-preset-trigger {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 7px 10px;
+    border: 1px solid var(--cz-border);
+    border-radius: 8px;
+    background: oklch(1 0 0 / 0.3);
+    color: var(--cz-fg);
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition:
+        background 0.15s,
+        border-color 0.15s;
+    text-align: left;
+}
+
+.dark .cz-preset-trigger {
+    background: oklch(0.222 0 90 / 0.3);
+}
+
+.cz-preset-trigger:hover {
+    background: var(--cz-hover-bg);
+}
+
+.cz-preset-trigger-left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+.cz-preset-trigger-placeholder {
+    color: var(--cz-muted);
+}
+
+.cz-preset-chevron {
+    width: 14px;
+    height: 14px;
+    color: var(--cz-muted);
+    flex-shrink: 0;
+    transition: transform 0.15s;
+}
+
+.cz-preset-chevron[data-open='true'] {
+    transform: rotate(180deg);
+}
+
 /* Preset grid */
 .cz-preset-list {
     display: grid;

--- a/resources/css/customizer.css
+++ b/resources/css/customizer.css
@@ -352,10 +352,17 @@
     width: 28px;
     height: 28px;
     border-radius: 50%;
-    border: 1px dashed var(--cz-muted);
+    border: 1px solid var(--cz-border);
     cursor: pointer;
     padding: 0;
     transition: transform 0.1s;
+    background-image: url(data:image/webp;base64,UklGRsIJAABXRUJQVlA4TLYJAAAvO8AOAAkxacJ++5e2QET/k+aFgkZSowHqX2s98GhQ2jaSZLhotXD7r/K5A2bats0ZxZSzENb/CfCBADw+GEZa2KKfAAiAwZqk4MgBDAVt20hz+LO+F0JETMCsanGqoIOTH5QbSZIkSWJefT6XjOWfuEVFZITtRQTEto0kSVTP7H35p3vtiJQUSZIkSWpZc/KHu9Ppj14QlBtJkiRJYlEze7yWf1Z3ulwpN5IkSZJEvfa7/HM6d4VFUogkSZIkqefwR7xTYXsPiIDYto0giZ7vv+G7+yjyz8+3x7Ysj7e/PA7+8/j49e3bjz+//vz48+vXr18/fvz49e3Hjx8//uVv/uYf/uIf/uL38/X5z8/Hz9fX5w/ftmPbtm3ZlrdlKa+P4zo5r83GLIZZmHHz33Pv2an3HhjHADwHhsmTyT79WLZj2bbH27K8bYtjOS8vOUGuY7eZOlRze3pzyL1tXryygfDlmTwBMmGfvmyP7diWbXnb3t6W26uRM7OG0/88uQKsRZfupkIgf7xmjcfkOUyY8ObLl+VYtm3ZtmVZlqd7ega3JFdRs3syU5t7k6lX1sBg+fNeHsxhMhze5MOXx/ZYtmVbtrdHz3nP595WyfC4Oe4tK9lQF2U5WVvGaLL8e/GPeAjAW+HLh+OxbduyvW23c/p1Pue9rgQBV8owh44oRVcE4FxfdjT7swMgb8X49nJsj+Xxtmy3Pvf7vufrvu3OFPfJ7YmskQx1siiUDTN4fGl2sF+/AG/XQJ+iqHGNeDXvfTLNbZzTlTJyOmHCMNIsMWQDqc03mzCJ6xfseiD7RECNepW3Z0ZTFt1zjNFqtABzDBvBaMbhInk8uhazyfb1cT2BzReuEVWf5e0xGHeOZtcp7plyG91EmaSYYRxzc5jHmyENQsyfuwk25RtcjMmTk0ncTSZlR8vuSWGqGpTBEmUjBrx5NLLBskVvf7qzCXypGMXreFp0aKowYQ/NejrLCQNgMAYQ18sXIwYI0aiPCuwb1JjjJbcnwNI9GeLuhk1yKxUSMYHFLPk3LocRg5mJ62e/fYehbxXEvC2a/zyG2lyJuN2RShgi12xkI43wvZYyXFiaXEzk+e0I+0aNPA6EenOKTBBK16Gw1MJoAogZbL6H2TQOV3logu2a23cavkSkvF3WcIyZpC6aMu7tVapoECMGgPmyMKm5jbZqNaxPNX4UOU603JY5pUw2tTDR3X+ZAlHNYmTD4wvC2FmBDIR8Bz8YPr2KFl2KklEJEXbWKbUw0oKyR+YLFoIw2bXVcB4+/ex75BEQLTqFLDmuAnrcI1lqiTIYwpdhEkp7HdOUcZ7z+kS/8HQJkfVEJ5OMQBqt90YL/jfjywYsJrVdU0MMjfWbviUnoBMBtKgQkYroOcsJTMgYefNG4Kxq1u25nhbZzsrbV/erOSayBqTKFIqupUCt7k2pmTDyrm+aDUzaqr27TTSoqUnrfvUxmZSBKWjQ5UShGHZOs6CNuL7HXhxdG0JGbQUZqC3N8UOPGAFgYLCYAAyMNDDw+LrxGGDuf/dtnZHFOlPTZALZpOSXDeBxDAAjptkx0mATm9KYsucyCqTctZosJUwmAgpv1Zbd/WYfEBgBjCBGg2FQNgfPEmjuLIHR9d9QzsqmaA4wbQXRXve+CWMEBgveptMDjGZIDxo5vBhmW79QyTKqrSaMFbWRMa37xcAxAybEwEDulGECMAI00Vyc+76X6gCR7dpqz4XVNpfJVvTDABBGAAyICSOAGBgYoNlz3/e+70lWBpmatsKQiQnrjOU3iIEAEAsAoMCbmDLQSsIymBBgzvC/sCzDTT9hQExgGJEYATNiIBCyaeJQ7z6/58/GatjKBrVZyZYBagv8gmYBAhjHhrcyjoHY4NK5jGXOnFCixAiPlQFs0WTI23nX0087MW4GgBhAADAxAuMoCPPOqHhWIiSOoWnLw3nTxKaB5rb45UA8YiAGAgACACKMKfGyE5hntUAApSHPbeasPUXThvPW+OkYQMQYx4gR/OcYDYqRlxGjsz6g4Fja5jEZDGAao/bU6JdjIB6IGAGMBgg0wDhw/GLnGAXrrDPE+LBgi02GtvOYaLPi4YeCQ8wSMPGIWMKgkc1N2Vw+WczoYDSvR0HZFie2OW/XY7d3eLLosfDbd+SNKTcDMg5sAgGYGDcY+xgFGEXsvM4CCAN5y1jGcHvF3OMHvxw3C28NgBiNAIHmzbF8gs2dTZERPE9sl8GMsUxerY3Y2hrgp86BglGMYDSIxTQBFLO8/2wuWAJLs5Ae1QgYaWLHrov2Svact3r+5wd/+PrJQAEWNCgwaASmMeWT958Yx1gQDrA9FRtCYkFXB2ZMk+emvB/hJx/NDy+moImXZgSapQEQ4/3nccTjEIwRKM9HFRDjBktsbrVZsWmLB35DfIkFm2IOmHEZ8SYC+HyMwCiAkUYGOBwBNDIumzIMw3myJ/CbkeMILM1LEwVvDlM2gZd9jJsF8dJIjE1ZzHpSCNkcj2IO6mkj45nwm5j4YeBYzOVhcDwiwozPx9IsOB5RllGAEDtzHA9zGcVVBtt5Wnv3kOE3ADc/eVzeXD5zIMIszUacz4cnEI8LHlEGMGLR43HI4zAOaIM5z/EQ+E0A851j+fLm2CAeR/NyLL8+PGVpRhkl8IgCbIJ2H58RzdKUXZ7qvetvx8Bz+AMAmj9scGd0NkCMkE+WPvaEwJQ9MQrGKAIz59XGZbM0HZq2wDOE4Q+IAY6f53EM3DHx0okP75gCAGUjjwObKBtAWs/HJ0bE2MRGbzeTTOA3xyMQzzd/+Awuw0gx430YZ19yZw8GIgYEmxAAOh9nRhoI7a9zPBky8JdHePvyQ3lz7HgK3vkgplzeI2ggA2FGAcaIwcdHbpZNxN0zk8nMgT9EPGLE4Ds/LKYMyCdl8TgGAcieC/Y4gYcpsTTq43kbXDBbmQHCE/4Sj+MRGOCe/9nZc2d8cEb04VmMAA3MzohhCjAEhufjaEbMZiAAefjLiPHhMQ7ENH+ey2bnnaXsQcfInssY8binY4bTs2OKAdTH82KICZMJQ8IfAscXHI8A4vmZHz7nYUIGOh5nTwCdgc2xkWaBERntfHYWABMGyMAfDjwOjMDjGDHo656QMMPj9DgwOx7EgJGlgQCN6+MDbJgwGcLAlzFiBDACiPzm+D7ff/YVgZ2ezr6W0jMABxiX4dlpBpDzHACTIQOBP+DAABAY4MPAOL5zXz19hby5YzZOjHFsAvsSiQEA8zEAns/MGQb//e/feOA4AHw4ZvziiC/jiO986ev4zuYSDY4wjtPjI3ZKdICD5uGJm+fMk3H9Aw==);
+    background-size: cover;
+    background-position: center;
+}
+
+.cz-custom-color[data-active='true'] {
+    background-image: none;
 }
 
 .cz-custom-color:hover {
@@ -379,6 +386,11 @@
     cursor: pointer;
     background: none;
     overflow: hidden;
+    opacity: 0;
+}
+
+.cz-custom-color[data-active='true'] .cz-color-input {
+    opacity: 1;
 }
 
 .cz-color-input::-webkit-color-swatch-wrapper {
@@ -405,6 +417,26 @@
 .cz-check {
     width: 14px;
     height: 14px;
+    color: #fff;
+}
+
+.cz-new {
+    width: 14px;
+    height: 14px;
+}
+
+.cz-new-wrapper {
+    width: 16px;
+    height: 16px;
+    background: rgba(255, 255, 255, 0.9);
+    color: #111;
+    border-radius: 50%;
+    position: relative;
+    padding: 1px;
+}
+
+.dark .cz-new-wrapper {
+    background: rgba(17, 17, 17, 0.9);
     color: #fff;
 }
 

--- a/resources/css/customizer.css
+++ b/resources/css/customizer.css
@@ -42,7 +42,7 @@
     color: var(--cz-fg);
     padding: 16px;
     box-shadow: var(--cz-shadow);
-    max-height: calc(100vh - 88px);
+    max-height: calc(100vh - 94px);
     overflow-y: auto;
 }
 @media (max-width: 380px) {
@@ -56,10 +56,25 @@
 }
 
 .cz-title {
-    margin-bottom: 16px;
+    margin-bottom: 6px;
     font-weight: 600;
     font-size: 13px;
     color: var(--cz-fg);
+}
+
+.cz-description {
+    margin-bottom: 16px;
+    font-size: 12px;
+    color: var(--cz-muted);
+}
+
+.cz-description code {
+    background: rgba(0, 0, 0, 0.05);
+    border-radius: 4px;
+    padding: 2px 4px;
+}
+.dark .cz-description code {
+    background: rgba(255, 255, 255, 0.05);
 }
 
 .cz-sections {

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -4,7 +4,8 @@ import { createInertiaApp } from '@inertiajs/react';
 import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { applyTheme, type ThemeConfig } from './lib/theme';
+import { Customizer, type CustomizerInitialData } from './components/customizer/customizer';
+import { applyTheme } from './lib/theme';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
@@ -12,7 +13,7 @@ createInertiaApp({
     title: (title) => (title ? `${title} - ${appName}` : appName),
     resolve: (name) => resolvePageComponent(`./pages/${name}.tsx`, import.meta.glob('./pages/**/*.tsx')),
     setup({ el, App, props }) {
-        const plume = (props.initialPage.props as Record<string, unknown>).plume as { theme: ThemeConfig } | undefined;
+        const plume = (props.initialPage.props as Record<string, unknown>).plume as CustomizerInitialData | undefined;
 
         if (plume?.theme) {
             applyTheme(plume.theme);
@@ -23,6 +24,7 @@ createInertiaApp({
         root.render(
             <StrictMode>
                 <App {...props} />
+                <Customizer initialData={plume} />
             </StrictMode>,
         );
     },

--- a/resources/js/components/customizer/customizer.tsx
+++ b/resources/js/components/customizer/customizer.tsx
@@ -1,6 +1,6 @@
 import '../../../css/customizer.css';
 
-import { Check, Paintbrush, Plus, RotateCcw } from 'lucide-react';
+import { Check, Paintbrush, Pipette, Plus, RotateCcw } from 'lucide-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -206,7 +206,7 @@ export function Customizer({ initialData }: { initialData?: CustomizerInitialDat
                                                     }, 100);
                                                 }}
                                             />
-                                            {isCustomColor && <Check className="cz-check" />}
+                                            {isCustomColor && <Pipette className="cz-check" />}
                                             {!isCustomColor && (
                                                 <span className="cz-new-wrapper">
                                                     <Plus className="cz-new" />

--- a/resources/js/components/customizer/customizer.tsx
+++ b/resources/js/components/customizer/customizer.tsx
@@ -1,6 +1,6 @@
 import '../../../css/customizer.css';
 
-import { Check, Paintbrush, RotateCcw } from 'lucide-react';
+import { Check, Paintbrush, Plus, RotateCcw } from 'lucide-react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -207,6 +207,11 @@ export function Customizer({ initialData }: { initialData?: CustomizerInitialDat
                                                 }}
                                             />
                                             {isCustomColor && <Check className="cz-check" />}
+                                            {!isCustomColor && (
+                                                <span className="cz-new-wrapper">
+                                                    <Plus className="cz-new" />
+                                                </span>
+                                            )}
                                         </label>
                                     </SwatchTooltip>
                                 </div>

--- a/resources/js/components/customizer/customizer.tsx
+++ b/resources/js/components/customizer/customizer.tsx
@@ -185,11 +185,7 @@ export function Customizer({ initialData }: { initialData?: CustomizerInitialDat
                                 <div>
                                     <div className="cz-label">Preset</div>
                                     <div className="cz-preset-dropdown">
-                                        <button
-                                            type="button"
-                                            className="cz-preset-trigger"
-                                            onClick={() => setPresetOpen(!presetOpen)}
-                                        >
+                                        <button type="button" className="cz-preset-trigger" onClick={() => setPresetOpen(!presetOpen)}>
                                             <span className="cz-preset-trigger-left">
                                                 {preset && presets[preset] ? (
                                                     <>
@@ -216,9 +212,7 @@ export function Customizer({ initialData }: { initialData?: CustomizerInitialDat
                                                         }}
                                                     >
                                                         <PresetDots preset={presets[name]} />
-                                                        <span className="cz-preset-name">
-                                                            {name.charAt(0).toUpperCase() + name.slice(1)}
-                                                        </span>
+                                                        <span className="cz-preset-name">{name.charAt(0).toUpperCase() + name.slice(1)}</span>
                                                     </button>
                                                 ))}
                                             </div>

--- a/resources/js/components/customizer/customizer.tsx
+++ b/resources/js/components/customizer/customizer.tsx
@@ -146,6 +146,10 @@ export function Customizer({ initialData }: { initialData?: CustomizerInitialDat
                 {open && config && (
                     <div className="cz-panel">
                         <div className="cz-title">Customizer</div>
+                        <div className="cz-description">
+                            Here you can customize your Plume theme. Options will be stored in your <code>content/config.yml</code>. This tool only
+                            shows in local environment.
+                        </div>
 
                         <div className="cz-sections">
                             {/* Preset list */}

--- a/resources/js/components/customizer/customizer.tsx
+++ b/resources/js/components/customizer/customizer.tsx
@@ -1,6 +1,6 @@
 import '../../../css/customizer.css';
 
-import { Check, Paintbrush, Pipette, Plus, RotateCcw, Save } from 'lucide-react';
+import { Check, ChevronDown, Paintbrush, Pipette, Plus, RotateCcw, Save } from 'lucide-react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -19,6 +19,8 @@ import {
 type PresetConfig = {
     primary: string;
     gray: string;
+    radius: string;
+    spacing: string;
     dark: boolean;
 };
 
@@ -85,6 +87,7 @@ export function Customizer({ initialData }: { initialData?: CustomizerInitialDat
     const [preset, setPreset] = useState(customizerConfig?.preset ?? '');
     const [customColor, setCustomColor] = useState('');
     const [saving, setSaving] = useState(false);
+    const [presetOpen, setPresetOpen] = useState(false);
     const buttonRef = useRef<HTMLButtonElement>(null);
     const customColorTimeout = useRef<ReturnType<typeof setTimeout>>(null);
 
@@ -134,9 +137,10 @@ export function Customizer({ initialData }: { initialData?: CustomizerInitialDat
             if (!presetConfig || !config) return;
 
             const next: ThemeConfig = {
-                ...config,
                 primary: presetConfig.primary,
                 gray: presetConfig.gray,
+                radius: presetConfig.radius,
+                spacing: presetConfig.spacing,
                 dark: presetConfig.dark,
             };
             setConfig(next);
@@ -176,23 +180,49 @@ export function Customizer({ initialData }: { initialData?: CustomizerInitialDat
                         </div>
 
                         <div className="cz-sections">
-                            {/* Preset list */}
+                            {/* Preset dropdown */}
                             {presetNames.length > 0 && (
                                 <div>
                                     <div className="cz-label">Preset</div>
-                                    <div className="cz-preset-list">
-                                        {presetNames.map((name) => (
-                                            <button
-                                                key={name}
-                                                type="button"
-                                                className="cz-preset-item"
-                                                data-active={preset === name}
-                                                onClick={() => switchPreset(name)}
-                                            >
-                                                <PresetDots preset={presets[name]} />
-                                                <span className="cz-preset-name">{name.charAt(0).toUpperCase() + name.slice(1)}</span>
-                                            </button>
-                                        ))}
+                                    <div className="cz-preset-dropdown">
+                                        <button
+                                            type="button"
+                                            className="cz-preset-trigger"
+                                            onClick={() => setPresetOpen(!presetOpen)}
+                                        >
+                                            <span className="cz-preset-trigger-left">
+                                                {preset && presets[preset] ? (
+                                                    <>
+                                                        <PresetDots preset={presets[preset]} />
+                                                        <span>{preset.charAt(0).toUpperCase() + preset.slice(1)}</span>
+                                                    </>
+                                                ) : (
+                                                    <span className="cz-preset-trigger-placeholder">Select a preset</span>
+                                                )}
+                                            </span>
+                                            <ChevronDown className="cz-preset-chevron" data-open={presetOpen} />
+                                        </button>
+                                        {presetOpen && (
+                                            <div className="cz-preset-list">
+                                                {presetNames.map((name) => (
+                                                    <button
+                                                        key={name}
+                                                        type="button"
+                                                        className="cz-preset-item"
+                                                        data-active={preset === name}
+                                                        onClick={() => {
+                                                            switchPreset(name);
+                                                            setPresetOpen(false);
+                                                        }}
+                                                    >
+                                                        <PresetDots preset={presets[name]} />
+                                                        <span className="cz-preset-name">
+                                                            {name.charAt(0).toUpperCase() + name.slice(1)}
+                                                        </span>
+                                                    </button>
+                                                ))}
+                                            </div>
+                                        )}
                                     </div>
                                 </div>
                             )}

--- a/resources/js/components/customizer/customizer.tsx
+++ b/resources/js/components/customizer/customizer.tsx
@@ -1,0 +1,308 @@
+import '../../../css/customizer.css';
+
+import { Check, Paintbrush, RotateCcw } from 'lucide-react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import {
+    applyTheme,
+    availableGrayPalettes,
+    availablePrimaryColors,
+    availableRadii,
+    availableSpacings,
+    grayColorPreview,
+    primaryColorPreview,
+    setDarkMode,
+    type ThemeConfig,
+} from '@/lib/theme';
+
+type PresetConfig = {
+    primary: string;
+    gray: string;
+    dark: boolean;
+};
+
+type CustomizerConfig = {
+    enabled: boolean;
+    preset: string;
+    presets: Record<string, PresetConfig>;
+};
+
+export type CustomizerInitialData = {
+    theme: ThemeConfig;
+    customizer?: CustomizerConfig;
+};
+
+async function postCustomizer(path: string, data: Record<string, unknown>): Promise<ThemeConfig> {
+    const token = document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content ?? '';
+
+    const r = await fetch(path, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            'X-CSRF-TOKEN': token,
+        },
+        body: JSON.stringify(data),
+    });
+    return await r.json();
+}
+
+const radiusPreviewValues: Record<string, string> = {
+    none: '0',
+    small: '3px',
+    medium: '6px',
+    large: '10px',
+};
+
+function PresetDots({ preset }: { preset: PresetConfig }) {
+    const primaryColor = primaryColorPreview[preset.primary] ?? preset.primary;
+    const grayColor = grayColorPreview[preset.gray] ?? preset.gray;
+
+    return (
+        <span className="cz-preset-dots" data-dark={preset.dark}>
+            <span className="cz-preset-dot" style={{ backgroundColor: primaryColor }} />
+            <span className="cz-preset-dot" style={{ backgroundColor: grayColor }} />
+        </span>
+    );
+}
+
+function SwatchTooltip({ label, children }: { label: string; children: React.ReactNode }) {
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>{children}</TooltipTrigger>
+            <TooltipContent className="plume-customizer-tooltip">{label}</TooltipContent>
+        </Tooltip>
+    );
+}
+
+export function Customizer({ initialData }: { initialData?: CustomizerInitialData }) {
+    const customizerConfig = initialData?.customizer;
+
+    const [open, setOpen] = useState(false);
+    const [config, setConfig] = useState<ThemeConfig | null>(initialData?.theme ?? null);
+    const [preset, setPreset] = useState(customizerConfig?.preset ?? '');
+    const [customColor, setCustomColor] = useState('');
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const customColorTimeout = useRef<ReturnType<typeof setTimeout>>(null);
+
+    const isCustomColor = config ? !availablePrimaryColors.includes(config.primary) : false;
+
+    useEffect(() => {
+        if (isCustomColor && config) {
+            setCustomColor(config.primary);
+        }
+    }, [isCustomColor, config]);
+
+    const updateConfig = useCallback(
+        (partial: Partial<ThemeConfig>) => {
+            if (!config) return;
+
+            const next = { ...config, ...partial };
+            setConfig(next);
+            applyTheme(next);
+
+            if ('dark' in partial) {
+                setDarkMode(next.dark);
+            }
+
+            postCustomizer('/_plume/customizer', partial).then();
+        },
+        [config],
+    );
+
+    const switchPreset = useCallback((name: string) => {
+        setPreset(name);
+        postCustomizer('/_plume/customizer', { theme: name }).then((resolved) => {
+            setConfig(resolved);
+            applyTheme(resolved);
+            if (resolved.dark !== document.documentElement.classList.contains('dark')) {
+                setDarkMode(resolved.dark);
+            }
+        });
+    }, []);
+
+    const resetDefaults = useCallback(() => {
+        postCustomizer('/_plume/customizer/reset', {}).then((resolved) => {
+            setConfig(resolved);
+            applyTheme(resolved);
+            if (resolved.dark !== document.documentElement.classList.contains('dark')) {
+                setDarkMode(resolved.dark);
+            }
+        });
+    }, []);
+
+    if (!customizerConfig?.enabled) {
+        return null;
+    }
+
+    const isDark = config?.dark ?? false;
+    const presets = customizerConfig.presets ?? {};
+    const presetNames = Object.keys(presets);
+
+    return (
+        <TooltipProvider>
+            <div className="plume-customizer">
+                {open && config && (
+                    <div className="cz-panel">
+                        <div className="cz-title">Customizer</div>
+
+                        <div className="cz-sections">
+                            {/* Preset list */}
+                            {presetNames.length > 0 && (
+                                <div>
+                                    <div className="cz-label">Preset</div>
+                                    <div className="cz-preset-list">
+                                        {presetNames.map((name) => (
+                                            <button
+                                                key={name}
+                                                type="button"
+                                                className="cz-preset-item"
+                                                data-active={preset === name}
+                                                onClick={() => switchPreset(name)}
+                                            >
+                                                <PresetDots preset={presets[name]} />
+                                                <span className="cz-preset-name">{name.charAt(0).toUpperCase() + name.slice(1)}</span>
+                                            </button>
+                                        ))}
+                                    </div>
+                                </div>
+                            )}
+
+                            {/* Primary color */}
+                            <div>
+                                <div className="cz-label">Primary color</div>
+                                <div className="cz-swatches">
+                                    {availablePrimaryColors.map((color) => (
+                                        <SwatchTooltip key={color} label={color}>
+                                            <button
+                                                type="button"
+                                                className="cz-swatch"
+                                                data-active={config.primary === color}
+                                                onClick={() => {
+                                                    setCustomColor('');
+                                                    updateConfig({ primary: color });
+                                                }}
+                                                style={{ backgroundColor: primaryColorPreview[color] ?? color }}
+                                            >
+                                                {config.primary === color && <Check className="cz-check" />}
+                                            </button>
+                                        </SwatchTooltip>
+                                    ))}
+                                    <SwatchTooltip label={isCustomColor ? `custom: ${config.primary}` : 'custom'}>
+                                        <label className="cz-custom-color" data-active={isCustomColor}>
+                                            <input
+                                                type="color"
+                                                className="cz-color-input"
+                                                value={customColor || '#000000'}
+                                                onChange={(e) => {
+                                                    const value = e.target.value;
+                                                    setCustomColor(value);
+                                                    if (customColorTimeout.current) {
+                                                        clearTimeout(customColorTimeout.current);
+                                                    }
+                                                    customColorTimeout.current = setTimeout(() => {
+                                                        updateConfig({ primary: value });
+                                                    }, 100);
+                                                }}
+                                            />
+                                            {isCustomColor && <Check className="cz-check" />}
+                                        </label>
+                                    </SwatchTooltip>
+                                </div>
+                            </div>
+
+                            {/* Gray palette */}
+                            <div>
+                                <div className="cz-label">Gray palette</div>
+                                <div className="cz-swatches">
+                                    {availableGrayPalettes.map((gray) => (
+                                        <SwatchTooltip key={gray} label={gray}>
+                                            <button
+                                                type="button"
+                                                className="cz-swatch"
+                                                data-active={config.gray === gray}
+                                                onClick={() => updateConfig({ gray })}
+                                                style={{ backgroundColor: grayColorPreview[gray] ?? gray }}
+                                            >
+                                                {config.gray === gray && <Check className="cz-check" />}
+                                            </button>
+                                        </SwatchTooltip>
+                                    ))}
+                                </div>
+                            </div>
+
+                            {/* Radius */}
+                            <div>
+                                <div className="cz-label">Radius</div>
+                                <div className="cz-pills">
+                                    {availableRadii.map((radius) => (
+                                        <button
+                                            key={radius}
+                                            type="button"
+                                            className="cz-pill"
+                                            data-active={config.radius === radius}
+                                            onClick={() => updateConfig({ radius: radius })}
+                                        >
+                                            <span className="cz-radius-icon" style={{ borderRadius: `${radiusPreviewValues[radius]} 0 0 0` }} />
+                                            {radius}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+
+                            {/* Spacing */}
+                            <div>
+                                <div className="cz-label">Spacing</div>
+                                <div className="cz-pills">
+                                    {availableSpacings.map((spacing) => (
+                                        <button
+                                            key={spacing}
+                                            type="button"
+                                            className="cz-pill"
+                                            data-active={config.spacing === spacing}
+                                            onClick={() => updateConfig({ spacing: spacing })}
+                                        >
+                                            <span className="cz-spacing-icon" data-spacing={spacing}>
+                                                <span />
+                                                <span />
+                                            </span>
+                                            {spacing}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+
+                            {/* Dark mode toggle */}
+                            <div className="cz-toggle-row">
+                                <div className="cz-label" style={{ marginBottom: 0 }}>
+                                    Dark mode
+                                </div>
+                                <button
+                                    type="button"
+                                    role="switch"
+                                    aria-checked={isDark}
+                                    className="cz-toggle"
+                                    data-on={isDark}
+                                    onClick={() => updateConfig({ dark: !isDark })}
+                                >
+                                    <span className="cz-toggle-knob" />
+                                </button>
+                            </div>
+
+                            {/* Restore defaults */}
+                            <button type="button" className="cz-reset" onClick={resetDefaults}>
+                                <RotateCcw style={{ width: 14, height: 14 }} />
+                                Restore defaults
+                            </button>
+                        </div>
+                    </div>
+                )}
+
+                <button ref={buttonRef} type="button" className="cz-fab" onClick={() => setOpen(!open)}>
+                    <Paintbrush style={{ width: 20, height: 20 }} />
+                </button>
+            </div>
+        </TooltipProvider>
+    );
+}

--- a/resources/js/components/ui/tooltip.tsx
+++ b/resources/js/components/ui/tooltip.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import * as React from "react"
+import { Tooltip as TooltipPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+                             delayDuration = 0,
+                             ...props
+                         }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+    return (
+        <TooltipPrimitive.Provider
+            data-slot="tooltip-provider"
+            delayDuration={delayDuration}
+            {...props}
+        />
+    )
+}
+
+function Tooltip({
+                     ...props
+                 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+    return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({
+                            ...props
+                        }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+    return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+                            className,
+                            sideOffset = 0,
+                            children,
+                            ...props
+                        }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+    return (
+        <TooltipPrimitive.Portal>
+            <TooltipPrimitive.Content
+                data-slot="tooltip-content"
+                sideOffset={sideOffset}
+                className={cn(
+                    "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 rounded-md px-3 py-1.5 text-xs bg-foreground text-background z-50 w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin)",
+                    className
+                )}
+                {...props}
+            >
+                {children}
+                <TooltipPrimitive.Arrow className="size-2.5 rotate-45 rounded-[2px] bg-foreground fill-foreground z-50 translate-y-[calc(-50%_-_2px)]" />
+            </TooltipPrimitive.Content>
+        </TooltipPrimitive.Portal>
+    )
+}
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }

--- a/resources/js/lib/theme.ts
+++ b/resources/js/lib/theme.ts
@@ -68,16 +68,6 @@ const primaryColors: Record<string, ColorScale> = {
             '--primary-foreground': 'oklch(0.205 0 0)',
         },
     },
-    blue: {
-        light: {
-            '--primary': 'oklch(0.546 0.245 262.881)',
-            '--primary-foreground': 'oklch(0.985 0 0)',
-        },
-        dark: {
-            '--primary': 'oklch(0.546 0.245 262.881)',
-            '--primary-foreground': 'oklch(0.985 0 0)',
-        },
-    },
     red: {
         light: {
             '--primary': 'oklch(0.577 0.245 27.325)',
@@ -88,26 +78,6 @@ const primaryColors: Record<string, ColorScale> = {
             '--primary-foreground': 'oklch(0.985 0 0)',
         },
     },
-    green: {
-        light: {
-            '--primary': 'oklch(0.527 0.185 155.023)',
-            '--primary-foreground': 'oklch(0.985 0 0)',
-        },
-        dark: {
-            '--primary': 'oklch(0.527 0.185 155.023)',
-            '--primary-foreground': 'oklch(0.985 0 0)',
-        },
-    },
-    violet: {
-        light: {
-            '--primary': 'oklch(0.541 0.281 293.009)',
-            '--primary-foreground': 'oklch(0.985 0 0)',
-        },
-        dark: {
-            '--primary': 'oklch(0.702 0.183 293.541)',
-            '--primary-foreground': 'oklch(0.205 0 0)',
-        },
-    },
     orange: {
         light: {
             '--primary': 'oklch(0.705 0.213 47.604)',
@@ -115,16 +85,6 @@ const primaryColors: Record<string, ColorScale> = {
         },
         dark: {
             '--primary': 'oklch(0.705 0.213 47.604)',
-            '--primary-foreground': 'oklch(0.985 0 0)',
-        },
-    },
-    rose: {
-        light: {
-            '--primary': 'oklch(0.585 0.233 14.645)',
-            '--primary-foreground': 'oklch(0.985 0 0)',
-        },
-        dark: {
-            '--primary': 'oklch(0.585 0.233 14.645)',
             '--primary-foreground': 'oklch(0.985 0 0)',
         },
     },
@@ -138,6 +98,36 @@ const primaryColors: Record<string, ColorScale> = {
             '--primary-foreground': 'oklch(0.205 0 0)',
         },
     },
+    yellow: {
+        light: {
+            '--primary': 'oklch(0.795 0.184 86.047)',
+            '--primary-foreground': 'oklch(0.205 0 0)',
+        },
+        dark: {
+            '--primary': 'oklch(0.795 0.184 86.047)',
+            '--primary-foreground': 'oklch(0.205 0 0)',
+        },
+    },
+    lime: {
+        light: {
+            '--primary': 'oklch(0.768 0.233 130.85)',
+            '--primary-foreground': 'oklch(0.205 0 0)',
+        },
+        dark: {
+            '--primary': 'oklch(0.768 0.233 130.85)',
+            '--primary-foreground': 'oklch(0.205 0 0)',
+        },
+    },
+    green: {
+        light: {
+            '--primary': 'oklch(0.527 0.185 155.023)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+        dark: {
+            '--primary': 'oklch(0.527 0.185 155.023)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+    },
     emerald: {
         light: {
             '--primary': 'oklch(0.596 0.178 163.231)',
@@ -145,6 +135,106 @@ const primaryColors: Record<string, ColorScale> = {
         },
         dark: {
             '--primary': 'oklch(0.596 0.178 163.231)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+    },
+    teal: {
+        light: {
+            '--primary': 'oklch(0.627 0.194 175.071)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+        dark: {
+            '--primary': 'oklch(0.627 0.194 175.071)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+    },
+    cyan: {
+        light: {
+            '--primary': 'oklch(0.715 0.143 215.221)',
+            '--primary-foreground': 'oklch(0.205 0 0)',
+        },
+        dark: {
+            '--primary': 'oklch(0.715 0.143 215.221)',
+            '--primary-foreground': 'oklch(0.205 0 0)',
+        },
+    },
+    sky: {
+        light: {
+            '--primary': 'oklch(0.685 0.169 237.323)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+        dark: {
+            '--primary': 'oklch(0.685 0.169 237.323)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+    },
+    blue: {
+        light: {
+            '--primary': 'oklch(0.546 0.245 262.881)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+        dark: {
+            '--primary': 'oklch(0.546 0.245 262.881)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+    },
+    indigo: {
+        light: {
+            '--primary': 'oklch(0.511 0.262 276.966)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+        dark: {
+            '--primary': 'oklch(0.511 0.262 276.966)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+    },
+    violet: {
+        light: {
+            '--primary': 'oklch(0.541 0.281 293.009)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+        dark: {
+            '--primary': 'oklch(0.702 0.183 293.541)',
+            '--primary-foreground': 'oklch(0.205 0 0)',
+        },
+    },
+    purple: {
+        light: {
+            '--primary': 'oklch(0.553 0.261 303.37)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+        dark: {
+            '--primary': 'oklch(0.553 0.261 303.37)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+    },
+    fuchsia: {
+        light: {
+            '--primary': 'oklch(0.591 0.293 322.896)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+        dark: {
+            '--primary': 'oklch(0.591 0.293 322.896)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+    },
+    pink: {
+        light: {
+            '--primary': 'oklch(0.592 0.249 0.584)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+        dark: {
+            '--primary': 'oklch(0.592 0.249 0.584)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+    },
+    rose: {
+        light: {
+            '--primary': 'oklch(0.585 0.233 14.645)',
+            '--primary-foreground': 'oklch(0.985 0 0)',
+        },
+        dark: {
+            '--primary': 'oklch(0.585 0.233 14.645)',
             '--primary-foreground': 'oklch(0.985 0 0)',
         },
     },
@@ -331,6 +421,42 @@ const grayPalettes: Record<string, ColorScale> = {
             '--ring': 'oklch(0.444 0.011 73.639)',
         },
     },
+    taupe: {
+        light: {
+            '--background': 'oklch(1 0 0)',
+            '--foreground': 'oklch(0.147 0.004 49.3)',
+            '--card': 'oklch(1 0 0)',
+            '--card-foreground': 'oklch(0.147 0.004 49.3)',
+            '--popover': 'oklch(1 0 0)',
+            '--popover-foreground': 'oklch(0.147 0.004 49.3)',
+            '--secondary': 'oklch(0.96 0.002 17.2)',
+            '--secondary-foreground': 'oklch(0.214 0.009 43.1)',
+            '--muted': 'oklch(0.96 0.002 17.2)',
+            '--muted-foreground': 'oklch(0.547 0.021 43.1)',
+            '--accent': 'oklch(0.96 0.002 17.2)',
+            '--accent-foreground': 'oklch(0.214 0.009 43.1)',
+            '--border': 'oklch(0.922 0.005 34.3)',
+            '--input': 'oklch(0.922 0.005 34.3)',
+            '--ring': 'oklch(0.714 0.014 41.2)',
+        },
+        dark: {
+            '--background': 'oklch(0.147 0.004 49.3)',
+            '--foreground': 'oklch(0.986 0.002 67.8)',
+            '--card': 'oklch(0.147 0.004 49.3)',
+            '--card-foreground': 'oklch(0.986 0.002 67.8)',
+            '--popover': 'oklch(0.147 0.004 49.3)',
+            '--popover-foreground': 'oklch(0.986 0.002 67.8)',
+            '--secondary': 'oklch(0.268 0.011 36.5)',
+            '--secondary-foreground': 'oklch(0.986 0.002 67.8)',
+            '--muted': 'oklch(0.268 0.011 36.5)',
+            '--muted-foreground': 'oklch(0.714 0.014 41.2)',
+            '--accent': 'oklch(0.268 0.011 36.5)',
+            '--accent-foreground': 'oklch(0.986 0.002 67.8)',
+            '--border': 'oklch(0.268 0.011 36.5)',
+            '--input': 'oklch(0.268 0.011 36.5)',
+            '--ring': 'oklch(0.367 0.016 35.7)',
+        },
+    },
     mauve: {
         light: {
             '--background': 'oklch(1 0 0)',
@@ -365,42 +491,6 @@ const grayPalettes: Record<string, ColorScale> = {
             '--border': 'oklch(0.263 0.024 320.12)',
             '--input': 'oklch(0.263 0.024 320.12)',
             '--ring': 'oklch(0.364 0.029 323.89)',
-        },
-    },
-    olive: {
-        light: {
-            '--background': 'oklch(1 0 0)',
-            '--foreground': 'oklch(0.153 0.006 107.1)',
-            '--card': 'oklch(1 0 0)',
-            '--card-foreground': 'oklch(0.153 0.006 107.1)',
-            '--popover': 'oklch(1 0 0)',
-            '--popover-foreground': 'oklch(0.153 0.006 107.1)',
-            '--secondary': 'oklch(0.966 0.005 106.5)',
-            '--secondary-foreground': 'oklch(0.228 0.013 107.4)',
-            '--muted': 'oklch(0.966 0.005 106.5)',
-            '--muted-foreground': 'oklch(0.58 0.031 107.3)',
-            '--accent': 'oklch(0.966 0.005 106.5)',
-            '--accent-foreground': 'oklch(0.228 0.013 107.4)',
-            '--border': 'oklch(0.93 0.007 106.5)',
-            '--input': 'oklch(0.93 0.007 106.5)',
-            '--ring': 'oklch(0.737 0.021 106.9)',
-        },
-        dark: {
-            '--background': 'oklch(0.153 0.006 107.1)',
-            '--foreground': 'oklch(0.988 0.003 106.5)',
-            '--card': 'oklch(0.153 0.006 107.1)',
-            '--card-foreground': 'oklch(0.988 0.003 106.5)',
-            '--popover': 'oklch(0.153 0.006 107.1)',
-            '--popover-foreground': 'oklch(0.988 0.003 106.5)',
-            '--secondary': 'oklch(0.286 0.016 107.4)',
-            '--secondary-foreground': 'oklch(0.988 0.003 106.5)',
-            '--muted': 'oklch(0.286 0.016 107.4)',
-            '--muted-foreground': 'oklch(0.737 0.021 106.9)',
-            '--accent': 'oklch(0.286 0.016 107.4)',
-            '--accent-foreground': 'oklch(0.988 0.003 106.5)',
-            '--border': 'oklch(0.286 0.016 107.4)',
-            '--input': 'oklch(0.286 0.016 107.4)',
-            '--ring': 'oklch(0.394 0.023 107.4)',
         },
     },
     mist: {
@@ -439,40 +529,40 @@ const grayPalettes: Record<string, ColorScale> = {
             '--ring': 'oklch(0.378 0.015 216)',
         },
     },
-    taupe: {
+    olive: {
         light: {
             '--background': 'oklch(1 0 0)',
-            '--foreground': 'oklch(0.147 0.004 49.3)',
+            '--foreground': 'oklch(0.153 0.006 107.1)',
             '--card': 'oklch(1 0 0)',
-            '--card-foreground': 'oklch(0.147 0.004 49.3)',
+            '--card-foreground': 'oklch(0.153 0.006 107.1)',
             '--popover': 'oklch(1 0 0)',
-            '--popover-foreground': 'oklch(0.147 0.004 49.3)',
-            '--secondary': 'oklch(0.96 0.002 17.2)',
-            '--secondary-foreground': 'oklch(0.214 0.009 43.1)',
-            '--muted': 'oklch(0.96 0.002 17.2)',
-            '--muted-foreground': 'oklch(0.547 0.021 43.1)',
-            '--accent': 'oklch(0.96 0.002 17.2)',
-            '--accent-foreground': 'oklch(0.214 0.009 43.1)',
-            '--border': 'oklch(0.922 0.005 34.3)',
-            '--input': 'oklch(0.922 0.005 34.3)',
-            '--ring': 'oklch(0.714 0.014 41.2)',
+            '--popover-foreground': 'oklch(0.153 0.006 107.1)',
+            '--secondary': 'oklch(0.966 0.005 106.5)',
+            '--secondary-foreground': 'oklch(0.228 0.013 107.4)',
+            '--muted': 'oklch(0.966 0.005 106.5)',
+            '--muted-foreground': 'oklch(0.58 0.031 107.3)',
+            '--accent': 'oklch(0.966 0.005 106.5)',
+            '--accent-foreground': 'oklch(0.228 0.013 107.4)',
+            '--border': 'oklch(0.93 0.007 106.5)',
+            '--input': 'oklch(0.93 0.007 106.5)',
+            '--ring': 'oklch(0.737 0.021 106.9)',
         },
         dark: {
-            '--background': 'oklch(0.147 0.004 49.3)',
-            '--foreground': 'oklch(0.986 0.002 67.8)',
-            '--card': 'oklch(0.147 0.004 49.3)',
-            '--card-foreground': 'oklch(0.986 0.002 67.8)',
-            '--popover': 'oklch(0.147 0.004 49.3)',
-            '--popover-foreground': 'oklch(0.986 0.002 67.8)',
-            '--secondary': 'oklch(0.268 0.011 36.5)',
-            '--secondary-foreground': 'oklch(0.986 0.002 67.8)',
-            '--muted': 'oklch(0.268 0.011 36.5)',
-            '--muted-foreground': 'oklch(0.714 0.014 41.2)',
-            '--accent': 'oklch(0.268 0.011 36.5)',
-            '--accent-foreground': 'oklch(0.986 0.002 67.8)',
-            '--border': 'oklch(0.268 0.011 36.5)',
-            '--input': 'oklch(0.268 0.011 36.5)',
-            '--ring': 'oklch(0.367 0.016 35.7)',
+            '--background': 'oklch(0.153 0.006 107.1)',
+            '--foreground': 'oklch(0.988 0.003 106.5)',
+            '--card': 'oklch(0.153 0.006 107.1)',
+            '--card-foreground': 'oklch(0.988 0.003 106.5)',
+            '--popover': 'oklch(0.153 0.006 107.1)',
+            '--popover-foreground': 'oklch(0.988 0.003 106.5)',
+            '--secondary': 'oklch(0.286 0.016 107.4)',
+            '--secondary-foreground': 'oklch(0.988 0.003 106.5)',
+            '--muted': 'oklch(0.286 0.016 107.4)',
+            '--muted-foreground': 'oklch(0.737 0.021 106.9)',
+            '--accent': 'oklch(0.286 0.016 107.4)',
+            '--accent-foreground': 'oklch(0.988 0.003 106.5)',
+            '--border': 'oklch(0.286 0.016 107.4)',
+            '--input': 'oklch(0.286 0.016 107.4)',
+            '--ring': 'oklch(0.394 0.023 107.4)',
         },
     },
 };
@@ -522,7 +612,38 @@ export function applyTheme(config: ThemeConfig): void {
     window.__plumeTheme = { light: lightVars, dark: darkVars };
 }
 
+export const availablePrimaryColors = Object.keys(primaryColors);
+
+export const availableGrayPalettes = Object.keys(grayPalettes);
+
+export const availableRadii = Object.keys(radiusStyles);
+
+export const availableSpacings = Object.keys(spacingSizes);
+
+export const primaryColorPreview: Record<string, string> = Object.fromEntries(
+    Object.entries(primaryColors).map(([name, scale]) => [name, scale.light['--primary']]),
+);
+
+export const grayColorPreview: Record<string, string> = Object.fromEntries(
+    Object.entries(grayPalettes).map(([name, scale]) => [name, scale.light['--muted-foreground']]),
+);
+
+export function setDarkMode(isDark: boolean): void {
+    const root = document.documentElement;
+    if (isDark) {
+        root.classList.add('dark');
+    } else {
+        root.classList.remove('dark');
+    }
+
+    const theme = window.__plumeTheme;
+    if (theme) {
+        applyVars(isDark ? theme.dark : theme.light);
+    }
+}
+
 declare global {
+    // noinspection JSUnusedGlobalSymbols
     interface Window {
         __plumeTheme?: { light: CssVars; dark: CssVars };
     }

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     @if (file_exists(public_path('hot')))
         @viteReactRefresh
         @vite(['resources/js/app.tsx'])

--- a/routes/customizer.php
+++ b/routes/customizer.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Meetplume\Plume\Http\Controllers\CustomizerController;
+
+Route::post('/_plume/customizer', [CustomizerController::class, 'update']);
+Route::post('/_plume/customizer/reset', [CustomizerController::class, 'reset']);

--- a/src/Http/Controllers/CustomizerController.php
+++ b/src/Http/Controllers/CustomizerController.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Meetplume\Plume\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Meetplume\Plume\Plume;
+use Meetplume\Plume\ThemeConfig;
+use Symfony\Component\Yaml\Yaml;
+
+class CustomizerController
+{
+    public function update(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'theme' => ['sometimes', 'string'],
+            'primary' => ['sometimes', 'string'],
+            'gray' => ['sometimes', 'string'],
+            'radius' => ['sometimes', 'string', 'in:'.implode(',', ThemeConfig::validRadius())],
+            'spacing' => ['sometimes', 'string', 'in:'.implode(',', ThemeConfig::validSpacing())],
+            'dark' => ['sometimes', 'boolean'],
+        ]);
+
+        $configPath = app(Plume::class)->configPath();
+
+        if ($configPath === null) {
+            return response()->json(['error' => 'No config path configured'], 422);
+        }
+
+        // When only theme (preset) is sent, rewrite config as just the theme key
+        if (isset($validated['theme']) && count($validated) === 1) {
+            $config = ['theme' => $validated['theme']];
+        } else {
+            $existing = $this->readExistingConfig($configPath);
+            /** @var array<string, mixed> $config */
+            $config = array_merge($existing, $validated);
+        }
+
+        ThemeConfig::write($configPath, $config);
+
+        $themeConfig = new ThemeConfig($configPath);
+        app()->instance(ThemeConfig::class, $themeConfig);
+
+        return response()->json($themeConfig->toArray());
+    }
+
+    public function reset(): JsonResponse
+    {
+        $configPath = app(Plume::class)->configPath();
+
+        if ($configPath === null) {
+            return response()->json(['error' => 'No config path configured'], 422);
+        }
+
+        $existing = $this->readExistingConfig($configPath);
+        $config = ThemeConfig::defaults();
+
+        // Preserve theme key if it exists
+        if (isset($existing['theme'])) {
+            $config = ['theme' => $existing['theme'], ...$config];
+        }
+
+        ThemeConfig::write($configPath, $config);
+
+        $themeConfig = new ThemeConfig($configPath);
+        app()->instance(ThemeConfig::class, $themeConfig);
+
+        return response()->json($themeConfig->toArray());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readExistingConfig(string $path): array
+    {
+        if (! file_exists($path)) {
+            return [];
+        }
+
+        /** @var array<string, mixed>|null $parsed */
+        $parsed = Yaml::parse((string) file_get_contents($path));
+
+        return is_array($parsed) ? $parsed : [];
+    }
+}

--- a/src/Page.php
+++ b/src/Page.php
@@ -19,9 +19,21 @@ class Page
         }
 
         if (app()->bound(ThemeConfig::class)) {
-            Inertia::share('plume', [
-                'theme' => app(ThemeConfig::class)->toArray(),
-            ]);
+            $themeConfig = app(ThemeConfig::class);
+
+            $plumeData = [
+                'theme' => $themeConfig->toArray(),
+            ];
+
+            if (app()->environment('local') && $themeConfig->isCustomizerEnabled()) {
+                $plumeData['customizer'] = [
+                    'enabled' => true,
+                    'preset' => $themeConfig->activePreset(),
+                    'presets' => ThemeConfig::presets(),
+                ];
+            }
+
+            Inertia::share('plume', $plumeData);
         }
 
         Inertia::setRootView('plume::app');

--- a/src/Plume.php
+++ b/src/Plume.php
@@ -9,10 +9,18 @@ use Meetplume\Plume\Http\Controllers\PageController;
 
 class Plume
 {
+    private ?string $configPath = null;
+
     public function config(string $configPath): void
     {
+        $this->configPath = $configPath;
         $themeConfig = new ThemeConfig($configPath);
         app()->instance(ThemeConfig::class, $themeConfig);
+    }
+
+    public function configPath(): ?string
+    {
+        return $this->configPath;
     }
 
     public function page(string $uri, string $filePath): PageDefinition

--- a/src/PlumeServiceProvider.php
+++ b/src/PlumeServiceProvider.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Meetplume\Plume;
 
-class PlumeServiceProvider extends \Illuminate\Support\ServiceProvider
+use Illuminate\Support\ServiceProvider;
+
+class PlumeServiceProvider extends ServiceProvider
 {
     public function register(): void
     {
@@ -18,5 +20,9 @@ class PlumeServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->publishes([
             __DIR__.'/../dist' => public_path('vendor/plume/dist'),
         ], 'plume-assets');
+
+        if ($this->app->environment('local', 'testing')) {
+            $this->loadRoutesFrom(__DIR__.'/../routes/customizer.php');
+        }
     }
 }

--- a/src/ThemeConfig.php
+++ b/src/ThemeConfig.php
@@ -95,7 +95,7 @@ class ThemeConfig
     }
 
     /**
-     * @return array<string, array{primary: string, gray: string, dark: bool}>
+     * @return array<string, array{primary: string, gray: string, radius: string, spacing: string, dark: bool}>
      */
     public static function presets(): array
     {
@@ -109,12 +109,7 @@ class ThemeConfig
         foreach (glob($dir.'/*.yml') ?: [] as $file) {
             $name = pathinfo($file, PATHINFO_FILENAME);
             $config = new self($file);
-            $data = $config->toArray();
-            $presets[$name] = [
-                'primary' => $data['primary'],
-                'gray' => $data['gray'],
-                'dark' => $data['dark'],
-            ];
+            $presets[$name] = $config->toArray();
         }
 
         ksort($presets);

--- a/tests/CustomizerTest.php
+++ b/tests/CustomizerTest.php
@@ -83,7 +83,7 @@ it('lists available presets with config', function (): void {
     $presets = ThemeConfig::presets();
 
     expect($presets)->toHaveKeys(['default', 'brutalist', 'catppuccin', 'forest', 'ocean', 'rose']);
-    expect($presets['ocean'])->toBe(['primary' => 'blue', 'gray' => 'slate', 'dark' => false]);
+    expect($presets['ocean'])->toBe(['primary' => 'blue', 'gray' => 'slate', 'radius' => 'medium', 'spacing' => 'default', 'dark' => false]);
     expect($presets['catppuccin'])->toHaveKey('dark', true);
 });
 

--- a/tests/CustomizerTest.php
+++ b/tests/CustomizerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use Meetplume\Plume\ThemeConfig;
+
+it('returns expected defaults', function (): void {
+    $defaults = ThemeConfig::defaults();
+
+    expect($defaults)->toBe([
+        'primary' => 'neutral',
+        'gray' => 'neutral',
+        'radius' => 'medium',
+        'spacing' => 'default',
+        'dark' => false,
+    ]);
+});
+
+it('writes valid YAML', function (): void {
+    $path = sys_get_temp_dir().'/plume_test_'.uniqid().'.yml';
+
+    ThemeConfig::write($path, [
+        'primary' => 'blue',
+        'gray' => 'slate',
+        'radius' => 'small',
+        'spacing' => 'compact',
+        'dark' => true,
+    ]);
+
+    expect(file_exists($path))->toBeTrue();
+
+    $config = new ThemeConfig($path);
+
+    expect($config->toArray())->toBe([
+        'primary' => 'blue',
+        'gray' => 'slate',
+        'radius' => 'small',
+        'spacing' => 'compact',
+        'dark' => true,
+    ]);
+
+    unlink($path);
+});
+
+it('reads customizer enabled by default', function (): void {
+    $path = sys_get_temp_dir().'/plume_test_'.uniqid().'.yml';
+    ThemeConfig::write($path, ['primary' => 'blue']);
+
+    $config = new ThemeConfig($path);
+
+    expect($config->isCustomizerEnabled())->toBeTrue();
+
+    unlink($path);
+});
+
+it('reads customizer disabled when set to false', function (): void {
+    $path = sys_get_temp_dir().'/plume_test_'.uniqid().'.yml';
+    ThemeConfig::write($path, ['customizer' => false, 'primary' => 'blue']);
+
+    $config = new ThemeConfig($path);
+
+    expect($config->isCustomizerEnabled())->toBeFalse();
+
+    unlink($path);
+});
+
+it('reads active preset from theme key', function (): void {
+    $config = new ThemeConfig(__DIR__.'/fixtures/config.yml');
+
+    expect($config->activePreset())->toBe('ocean');
+});
+
+it('returns empty preset when no theme key', function (): void {
+    $path = sys_get_temp_dir().'/plume_test_'.uniqid().'.yml';
+    ThemeConfig::write($path, ['primary' => 'blue']);
+
+    $config = new ThemeConfig($path);
+
+    expect($config->activePreset())->toBe('');
+
+    unlink($path);
+});
+
+it('lists available presets with config', function (): void {
+    $presets = ThemeConfig::presets();
+
+    expect($presets)->toHaveKeys(['default', 'brutalist', 'catppuccin', 'forest', 'ocean', 'rose']);
+    expect($presets['ocean'])->toBe(['primary' => 'blue', 'gray' => 'slate', 'dark' => false]);
+    expect($presets['catppuccin'])->toHaveKey('dark', true);
+});
+
+it('stores and returns config path on Plume singleton', function (): void {
+    $plume = new \Meetplume\Plume\Plume;
+
+    expect($plume->configPath())->toBeNull();
+});

--- a/tests/fixtures/config.yml
+++ b/tests/fixtures/config.yml
@@ -1,0 +1,6 @@
+theme: ocean
+primary: blue
+gray: slate
+radius: small
+spacing: compact
+dark: true


### PR DESCRIPTION
Adds a local-only theme customizer (dev tool, not exposed in production).                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                   
## Backend:

- [x] new `CustomizerController` with update and reset endpoints (POST `/_plume/customizer`)
- [x] routes only registered in local/testing environments
- [x] Plume stores and exposes config path so the controller can read/write the YAML config
- [x] customizer data shared via Inertia only in local env

## Frontend:

- [x] new `<Customizer>` React component
- [x] dedicated customizer.css for isolated styling
- [x] new Tooltip UI component (from shadcn)

## Tests:

- [x] unit tests for `ThemeConfig` (defaults, write/read YAML, customizer flag, presets)
- [x] feature tests for the controller endpoints